### PR TITLE
JENKINS-38484 Use non-deprecated API (now contributeTestData)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -215,3 +215,6 @@ pip-log.txt
 .mr.developer.cfg
 /target
 /work*
+
+.idea
+test-stability.iml


### PR DESCRIPTION
The getTestData method on the TestDataPublisher is deprecated. It
doesn't work with Pipeline builds and makes them hang. This commit
changes the plugin to use the new contributeTestData method...
