### PR TITLE
JENKINS-42610 - Use TestObject.getRun in buildUpInitialHistory

### DIFF
--- a/src/main/java/de/esailors/jenkins/teststability/StabilityTestDataPublisher.java
+++ b/src/main/java/de/esailors/jenkins/teststability/StabilityTestDataPublisher.java
@@ -145,7 +145,7 @@ public class StabilityTestDataPublisher extends TestDataPublisher {
 		hudson.tasks.test.TestResult previousResult = getPreviousResult(result);
 		while (previousResult != null) {
 			testResultsFromNewestToOldest.add(
-					new Result(previousResult.getOwner().getNumber(), previousResult.isPassed()));
+					new Result(previousResult.getRun().getNumber(), previousResult.isPassed()));
 			previousResult = previousResult.getPreviousResult();
 		}
 


### PR DESCRIPTION
On pipeline jobs, the call to deprecated API TestObject.getOwner() returns null, as reported on https://issues.jenkins-ci.org/browse/JENKINS-36504 .

This causes an NPE on previousResult.getOwner().getNumber() ; using TestObject.getRun() avoid this issue.